### PR TITLE
Bump default LabKey image to 26.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ There are a substantial number of configuration options available.  The `docker-
 We only publish tagged versions to Docker Hub (we don't publish a 'latest' tag). To upgrade to a new version of LabKey Community edition, you have two options:
 1. Edit the `docker-compose.yml` file and update the `image` version to the LabKey version you wish to use. 
 2. Launch a new version from the command line by setting `COMPOSE_IMAGE`.
-`COMPOSE_IMAGE="labkeyteamcity/labkey-community:26.3.0" docker compose up community --detach`
+`COMPOSE_IMAGE="labkeyteamcity/labkey-community:26.7.0" docker compose up community --detach`
 
 ### PostgreSQL version
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 
 services:
   community:
-    image: ${COMPOSE_IMAGE:-labkeyteamcity/labkey-community:26.3.0}
+    image: ${COMPOSE_IMAGE:-labkeyteamcity/labkey-community:26.7.0}
     platform: linux/amd64
     container_name: labkey-community
     depends_on:


### PR DESCRIPTION
## Rationale
Update default `COMPOSE_IMAGE` tag from 26.3.0 to 26.7.0 so `docker compose up` launches the current LabKey Community release out of the box.

## Related Pull Requests
None

## Changes
`docker-compose.yml` default image tag bumped 26.3.0 to 26.7.0; `README.md` example command updated to match. Verified: `docker compose config` valid, `docker pull --platform linux/amd64 labkeyteamcity/labkey-community:26.7.0` succeeds, stack starts clean (`community` and `pg-community` both healthy, HTTP 302 from `https://localhost:8443`, no errors in logs), torn down after test.